### PR TITLE
Fix: Refresh quest message

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -174,9 +174,10 @@ async def refresh_quest(interaction: discord.Interaction, type: str):
     if quest:
         channel = bot.get_channel(config.QUEST_CHANNEL_ID)
         if channel:
-            prefix = "☀️ **Daily Quest Refreshed!**" if type == "Daily_Quests" else "🔥 **Weekly Quest Refreshed!**"
+            # Matches the exact wording from the automatic loops
+            announcement_text = "☀️ **Today's Daily Quest is live!**" if type == "Daily_Quests" else "🔥 **A new Weekly Quest has appeared!**"
             embed = format_quest_embed(quest, type)
-            await channel.send(content=f"{prefix}\n*Requested by {interaction.user.mention}*", embed=embed)
+            await channel.send(content=announcement_text, embed=embed)
             await interaction.followup.send(f"✅ Refreshed {type}!")
 
 # The /post_specific_quest


### PR DESCRIPTION
## Summary

Make `/refresh_quest` announcements match the standard quest wording for both daily and weekly quests.

## Problem

The `/refresh_quest` command currently posts messages like:

- `☀️ Daily Quest Refreshed!`
- `🔥 Weekly Quest Refreshed!`
- `Requested by @...`

This is inconsistent with the normal quest announcement wording used by the automated quest loops and `/post_specific_quest`.

## Solution

Update `/refresh_quest` to post the **same announcement text** as the automatic quest posts:

- Daily: `☀️ **Today's Daily Quest is live!**`
- Weekly: `🔥 **A new Weekly Quest has appeared!**`

Also removes the extra “Requested by …” line.

## Changes

- **`bot.py`**
  - Updated `refresh_quest` to use `announcement_text` instead of `prefix`
  - Ensures refreshed quests look identical to standard quest announcements

## Test Plan

- Run `/refresh_quest` with `Daily`
  - Verify the post says `☀️ **Today's Daily Quest is live!**`
- Run `/refresh_quest` with `Weekly`
  - Verify the post says `🔥 **A new Weekly Quest has appeared!**`
- Confirm no “Requested by …” text appears